### PR TITLE
Adding a link to a tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@
 - [Vue JS 2 Tutorials](https://www.youtube.com/playlist?list=PL4cUxeGkcC9gQcYgjhBoeQH7wiAyZNrYa) on Youtube by [The Net Ninja](https://www.thenetninja.co.uk)
 - [Add a headless CMS to VueJs in 5 Minutes](https://www.storyblok.com/tp/add-a-headless-CMS-to-vuejs-in-5-minutes)
 - [vue 架构中的 Watcher](https://github.com/dengwanc/dengwanc.github.io/issues/11)
-
+- [Migrating from KnockoutJS to VueJS](https://jes.al/2017/05/migrating-from-knockoutjs-to-vuejs/) by [@jesalg](https://twitter.com/jesalg)
 
 ### Examples
 


### PR DESCRIPTION
Linking to a blog post about how to migrate to VueJS from KnockoutJS https://jes.al/2017/05/migrating-from-knockoutjs-to-vuejs/